### PR TITLE
CC-6666 Fix value mismatch for "ShipmentMethod.name"

### DIFF
--- a/tests/_data/shipment_method.databuilder.xml
+++ b/tests/_data/shipment_method.databuilder.xml
@@ -5,7 +5,7 @@
         xsi:schemaLocation="spryker:transfer-01 http://static.spryker.com/transfer-01.xsd">
 
     <transfer name="ShipmentMethod">
-        <property name="name" dataBuilderRule="word(5)" />
+        <property name="name" dataBuilderRule="word" />
         <property name="isActive" dataBuilderRule="=1" />
         <property name="fkShipmentCarrier" dataBuilderRule="=1" />
     </transfer>


### PR DESCRIPTION
- Developer(s): @m7moud

- Target version: 6.10.1

- Branch: hotfix/cc-6666-shipment-6-10-0

- Release: https://release.spryker.com/release/hotfix?pr=https%3A%2F%2Fgithub.com%2Fspryker%2Fshipment%2Fpull%2F1

#### Release Table

   Module                | Release Type         | Constraint Updates         |
   :--------------------- | :------------------------ | :--------------------- |
   Shipment              | patch                 |                       |

#### Release Notes

{skip}

-----------------------------------------

#### Module Shipment

##### Change log

Bugfixes

- Fixed databuilder value mismatch issue for `ShipmentMethod.name`.