### PR TITLE
CC-30968 Add config to enable/disable quote persisting on expanding quote with shipment groups.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
   "license": "proprietary",
   "require": {
     "php": ">=7.1",
-    "spryker/calculation": "^4.8.0",
+    "spryker/calculation": "^4.9.0",
     "spryker/calculation-extension": "^1.0.0",
     "spryker/country": "^3.0.0",
     "spryker/currency": "^3.1.0",

--- a/src/Spryker/Zed/Shipment/Business/ShipmentBusinessFactory.php
+++ b/src/Spryker/Zed/Shipment/Business/ShipmentBusinessFactory.php
@@ -601,6 +601,7 @@ class ShipmentBusinessFactory extends AbstractBusinessFactory
             $this->createExpenseSanitizer(),
             $this->createShipmentMapper(),
             $this->getCalculationFacade(),
+            $this->getConfig(),
             $this->getShipmentGroupsSanitizerPlugins()
         );
     }

--- a/src/Spryker/Zed/Shipment/Business/ShipmentFacadeInterface.php
+++ b/src/Spryker/Zed/Shipment/Business/ShipmentFacadeInterface.php
@@ -370,6 +370,7 @@ interface ShipmentFacadeInterface
      * - Expands quote items with shipments.
      * - Expands quote expenses with shipment expenses.
      * - Executes CalculationFacadeInterface::recalculateQuote() method.
+     * - Uses {@link \Spryker\Zed\Shipment\ShipmentConfig::shouldExecuteQuotePostRecalculationPlugins()} method to determine if quote post recalculate plugins should be executed.
      *
      * @api
      *

--- a/src/Spryker/Zed/Shipment/ShipmentConfig.php
+++ b/src/Spryker/Zed/Shipment/ShipmentConfig.php
@@ -21,4 +21,18 @@ class ShipmentConfig extends AbstractBundleConfig
     {
         return $this->getSharedConfig()::SHIPMENT_EXPENSE_TYPE;
     }
+
+    /**
+     * Specification:
+     * - If set to `true` a stack of {@link \Spryker\Zed\CalculationExtension\Dependency\Plugin\QuotePostRecalculatePluginStrategyInterface} will be executed after quote recalculation.
+     * - Impacts {@link \Spryker\Zed\Shipment\Business\ShipmentFacade::expandQuoteWithShipmentGroups()} method.
+     *
+     * @api
+     *
+     * @return bool
+     */
+    public function shouldExecuteQuotePostRecalculationPlugins(): bool
+    {
+        return true;
+    }
 }


### PR DESCRIPTION
- Developer(s): @AsonUnique

- Ticket: https://spryker.atlassian.net/browse/CC-30986

- Release Group: https://release.spryker.com/release-groups/view/4968

- merge: squash

- Version: 7.4.0

#### Release Table

   Module                | Release Type         | Constraint Updates         |
   :--------------------- | :------------------------ | :--------------------- |
   Shipment              | minor                 |                       |

-----------------------------------------

#### Module Shipment

##### Change log

Improvements

- Introduced `ShipmentConfig::shouldExecuteQuotePostRecalculationPlugins()` to define if quote post recalculation should be executed when the `ShipmentToCalculationFacadeInterface::recalculateQuote()`  method is called.
- Adjusted `ShipmentFacade::expandQuoteWithShipmentGroups()` so it will use the `ShipmentConfig::shouldExecuteQuotePostRecalculationPlugins()` config, in order to determine if quote post recalculate plugins should be executed during quote recalculation.
- Increased `Calculation` module version dependency.
